### PR TITLE
Allow users to override OPENAI_API_URL to use a local LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,9 @@ Create `~/.config/unibear/config.json`:
 
 Unibear supports using local LLMs via the OpenAI chat completions API by providing `OPENAI_API_URL` environment variable.
 
-Note: even if no API key is required, you may still need to provide a dummy value.
-
 ```bash
 # Example using Ollama:
-OPENAI_API_URL=http://localhost:11434/v1 OPENAI_API_KEY=unibear unibear
+OPENAI_API_URL=http://localhost:11434/v1 unibear
 ```
 
 ## Modes

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ unibear
 - 🔧 Built-in Git, filesystem and web-search tools
 - 🤝 Plan & pair-program with your AI buddy before applying edits
 - 🖥️ Responsive TUI
+- 📁 Ability to use a local LLM server that supports the OpenAI chat completions API (eg. Ollama)
 
 <br>
 
@@ -102,6 +103,17 @@ Create `~/.config/unibear/config.json`:
 ```
 
 <br>
+
+### Using a local LLM (eg. Ollama)
+
+Unibear supports using local LLMs via the OpenAI chat completions API by providing `OPENAI_API_URL` environment variable.
+
+Note: even if no API key is required, you may still need to provide a dummy value.
+
+```bash
+# Example using Ollama:
+OPENAI_API_URL=http://localhost:11434/v1 OPENAI_API_KEY=unibear unibear
+```
 
 ## Modes
 

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -9,6 +9,7 @@ import { getTools } from "./tools.ts";
 
 const MAX_HISTORY = 16; // trim history to last N messages
 export const openai = new OpenAI({
+  baseURL: Deno.env.get("OPENAI_API_URL") ?? undefined,
   apiKey: Deno.env.get("OPENAI_API_KEY") ?? "",
 });
 


### PR DESCRIPTION
This commit adds the ability to override the OpenAI API endpoint. Ollama (and others) conform to the OpenAI chat completions API, which allows us to run Unibear against a local LLM.

## Usage

For example, against Ollama models
```bash
OPENAI_API_URL=http://localhost:11434/v1 OPENAI_API_KEY=unibear unibear
```