### PR TITLE
Fix SIGWINCH Crash on Windows

### DIFF
--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -23,7 +23,9 @@ export const useStore = create<Store>((set, get) => ({
       set({ dimensions: { cols: columns, rows } });
       Logger.debug("Console dimensions updated", { columns, rows }); // Added
     };
-    Deno.addSignalListener("SIGWINCH", setDimensions);
+    if (Deno.build.os !== "windows") {
+      Deno.addSignalListener("SIGWINCH", setDimensions);
+    }
     setDimensions();
   },
   injectClipboard: () => {


### PR DESCRIPTION
Fixes #18

Introduces a change to the `src/store/main.ts,` such that signal listeners resizing the console (`SIGWINCH`) are added on non-Windows platforms, but it's ignored on Windows since it crashes Deno as that is not expected in a Windows env. 

* Affects: [`src/store/main.ts`](diffhunk://#diff-f29d39903c159dbbc78054db5d1f97a35d4ad7726f873486d21d31a8fba7735dR26-R28)

Compiles just fine, ran

```
# watch & run in dev mode
deno task dev

# compile a standalone binary
deno task compile

# faster compile skipping type checks
deno task compile-no-check
```


```powershell
PS S:\unibearpatch\unibear> deno task compile
Task compile deno compile -A -o bin/unibear src/main.ts
Check file:///S:/unibearpatch/unibear/src/main.ts
Compile file:///S:/unibearpatch/unibear/src/main.ts to bin/unibear.exe

Embedded Files

unibear.exe
├─┬ .deno_compile_node_modules (34.15MB - 32.76MB unique)
│ └─┬ localhost (34.15MB - 32.76MB unique)
│   ├── @alcalzone/ansi-tokenize/* (23.8KB)
│   ├── @colors/colors/* (39.28KB - 39.1KB unique)
│   ├── @electron/get/* (95.67KB - 87.42KB unique)
│   ├── @sindresorhus/is/* (96.5KB - 96.44KB unique)
│   ├── @szmarczak/http-timer/* (6.52KB - 6.51KB unique)
│   ├─┬ @types (4.91MB - 4.89MB unique)
│   │ ├── marked-terminal/* (7.06KB - 7.05KB unique)
│   │ ├── node/* (4.89MB - 4.87MB unique)
│   │ └── node-fetch/* (12.1KB - 10.96KB unique)
│   ├── abort-controller/3.0.0/* (75.86KB - 75.83KB unique)
│   ├── agentkeepalive/4.6.0/* (33.81KB - 33.77KB unique)
│   ├─┬ ansi-escapes (34.96KB - 32.71KB unique)
│   │ ├── 6.2.1/* (17.36KB - 16.27KB unique)
│   │ └── 7.0.0/* (17.59KB - 16.44KB unique)
│   ├─┬ ansi-regex (11.35KB - 9.15KB unique)
│   │ ├── 5.0.1/* (5.9KB - 4.8KB unique)
│   │ └── 6.1.0/* (5.45KB - 4.35KB unique)
│   ├─┬ ansi-styles (43.86KB - 40.56KB unique)
│   │ ├── 3.2.1/* (9.58KB - 8.48KB unique)
│   │ ├── 4.3.0/* (17.02KB - 15.91KB unique)
│   │ └── 6.2.1/* (17.26KB - 16.17KB unique)
│   ├── any-promise/1.3.0/* (22.66KB - 22.23KB unique)
│   ├── args/5.0.3/* (31.22KB - 31.13KB unique)
│   ├── asynckit/0.4.0/* (27.53KB - 27.28KB unique)
│   ├── atomic-sleep/1.0.0/* (6.98KB - 6.96KB unique)
│   ├── auto-bind/5.0.1/* (6.8KB - 5.71KB unique)
│   ├── balanced-match/1.0.2/* (7.27KB - 7.24KB unique)
│   ├── boolean/3.2.0/* (12.96KB - 12.92KB unique)
│   ├── brace-expansion/1.1.11/* (11.22KB - 11.21KB unique)
│   ├── buffer-crc32/0.2.13/* (8.18KB - 8.17KB unique)
│   ├── buffer-from/1.1.2/* (5.27KB - 5.26KB unique)
│   ├── cacheable-request/6.1.0/* (16.75KB - 16.74KB unique)
│   ├── call-bind-apply-helpers/1.0.2/* (16.98KB - 16.83KB unique)
│   ├── camelcase/5.0.0/* (5.39KB - 4.29KB unique)
│   ├─┬ chalk (104.91KB - 96.52KB unique)
│   │ ├── 2.4.2/* (26.9KB - 25.79KB unique)
│   │ ├── 4.1.2/* (34.65KB - 33.53KB unique)
│   │ └── 5.4.1/* (43.36KB - 37.19KB unique)
│   ├── char-regex/1.0.2/* (5.26KB - 5.24KB unique)
│   ├── cli-boxes/3.0.0/* (6.84KB - 5.74KB unique)
│   ├── cli-cursor/4.0.0/* (4.51KB - 3.42KB unique)
│   ├── cli-highlight/2.1.11/* (43.53KB - 43.4KB unique)
│   ├── cli-table3/0.6.5/* (45.9KB - 45.85KB unique)
│   ├── cli-truncate/4.0.0/* (10.8KB - 9.71KB unique)
│   ├── clipboardy/4.0.0/* (894.14KB - 893.05KB unique)
│   ├── cliui/7.0.4/* (29.89KB - 29.88KB unique)
│   ├── clone-response/1.0.3/* (4.79KB - 3.73KB unique)
│   ├── code-excerpt/4.0.0/* (4.28KB)
│   ├─┬ color-convert (54.37KB - 49.08KB unique)
│   │ ├── 1.9.3/* (27.16KB - 27.14KB unique)
│   │ └── 2.0.1/* (27.21KB - 21.94KB unique)
│   ├─┬ color-name (21.59KB - 13.18KB unique)
│   │ ├── 1.1.3/* (12.21KB - 12.19KB unique)
│   │ └── 1.1.4/* (9.39KB - 1010B unique)
│   ├── combined-stream/1.0.8/* (11.91KB - 11.89KB unique)
│   ├── commander/2.19.0/* (60.56KB - 60.55KB unique)
│   ├── concat-map/0.0.1/* (5.19KB - 5.14KB unique)
│   ├── concat-stream/1.6.2/* (9.75KB - 9.74KB unique)
│   ├── config-chain/1.1.13/* (15.09KB)
│   ├── convert-to-spaces/2.0.1/* (3.07KB)
│   ├── core-util-is/1.0.3/* (5.54KB)
│   ├── cross-spawn/7.0.6/* (16.36KB - 16.33KB unique)
│   ├── dateformat/3.0.3/* (15.13KB - 15.12KB unique)
│   ├─┬ debug (94.98KB - 94.32KB unique)
│   │ ├── 2.6.9/* (52.38KB - 51.87KB unique)
│   │ └── 4.4.0/* (42.6KB - 42.45KB unique)
│   ├── decompress-response/3.3.0/* (3.9KB - 3.89KB unique)
│   ├── defer-to-connect/1.1.3/* (5.75KB - 4.65KB unique)
│   ├── define-data-property/1.1.4/* (31.39KB - 31.36KB unique)
│   ├── define-properties/1.2.1/* (13.96KB - 13.81KB unique)
│   ├── delayed-stream/1.0.0/* (8.46KB - 7.38KB unique)
│   ├── detect-node/2.1.0/* (3.03KB - 3KB unique)
│   ├── diff/7.0.0/* (609.9KB - 539.25KB unique)
│   ├── dunder-proto/1.0.1/* (13.95KB - 13.65KB unique)
│   ├── duplexer3/0.1.5/* (6.02KB)
│   ├── electron/9.4.4/* (568.04KB - 567.98KB unique)
│   ├─┬ emoji-regex (79.38KB - 78.25KB unique)
│   │ ├── 10.4.0/* (31.73KB - 31.71KB unique)
│   │ └── 8.0.0/* (47.65KB - 46.54KB unique)
│   ├── emojilib/2.4.0/* (319.31KB)
│   ├── encodeurl/1.0.2/* (8.2KB - 8.19KB unique)
│   ├── end-of-stream/1.4.4/* (6.5KB - 6.49KB unique)
│   ├── env-paths/2.2.1/* (10.33KB - 9.21KB unique)
│   ├── environment/1.1.0/* (8.84KB - 7.75KB unique)
│   ├── es-define-property/1.0.1/* (11.22KB - 10.01KB unique)
│   ├── es-errors/1.3.0/* (13.2KB - 11.93KB unique)
│   ├── es-object-atoms/1.1.1/* (12.31KB - 11.15KB unique)
│   ├── es-set-tostringtag/2.1.0/* (15.24KB - 15.07KB unique)
│   ├── es-toolkit/1.33.0/* (2.66MB - 2.07MB unique)
│   ├── es6-error/4.1.1/* (10.26KB - 10.2KB unique)
│   ├── escalade/3.2.0/* (12.54KB - 12.49KB unique)
│   ├─┬ escape-string-regexp (10.89KB - 8.2KB unique)
│   │ ├── 1.0.5/* (3.08KB - 3.07KB unique)
│   │ ├── 2.0.0/* (3.65KB - 2.54KB unique)
│   │ └── 4.0.0/* (4.16KB - 2.59KB unique)
│   ├── event-target-shim/5.0.1/* (185.77KB - 185.75KB unique)
│   ├── eventemitter2/5.0.1/* (39.88KB - 39.84KB unique)
│   ├── execa/8.0.1/* (78.42KB - 77.33KB unique)
│   ├── extract-zip/1.7.0/* (11.04KB - 11KB unique)
│   ├── fast-json-parse/1.0.3/* (7.35KB - 7.31KB unique)
│   ├── fast-redact/2.1.0/* (69.71KB - 69.54KB unique)
│   ├── fast-safe-stringify/2.1.1/* (39.39KB - 39.32KB unique)
│   ├── fd-slicer/1.1.0/* (29.95KB - 29.93KB unique)
│   ├── flatstr/1.0.12/* (12.76KB - 12.71KB unique)
│   ├── form-data/4.0.2/* (31.62KB - 31.57KB unique)
│   ├── form-data-encoder/1.7.2/* (47.28KB - 46.78KB unique)
│   ├── formdata-node/4.4.1/* (86.76KB - 85.29KB unique)
│   ├── fs-extra/8.1.0/* (126.55KB - 126.42KB unique)
│   ├── fullscreen-ink/0.0.2/* (9.62KB - 9.52KB unique)
│   ├── function-bind/1.1.2/* (32.34KB - 32.09KB unique)
│   ├── get-caller-file/2.0.5/* (5.29KB - 5.27KB unique)
│   ├── get-east-asian-width/1.3.0/* (15.49KB - 14.4KB unique)
│   ├── get-intrinsic/1.3.0/* (46.65KB - 46.49KB unique)
│   ├── get-proto/1.0.1/* (11.81KB - 11.59KB unique)
│   ├─┬ get-stream (45.51KB - 42.21KB unique)
│   │ ├── 4.1.0/* (8.17KB - 7.08KB unique)
│   │ ├── 5.2.0/* (12.61KB - 11.5KB unique)
│   │ └── 8.0.1/* (24.72KB - 23.63KB unique)
│   ├── global-agent/3.0.0/* (132.72KB - 110.95KB unique)
│   ├── global-tunnel-ng/2.7.1/* (39.29KB - 39.25KB unique)
│   ├── globalthis/1.0.4/* (24.19KB - 24.06KB unique)
│   ├── gopd/1.2.0/* (10.65KB - 10.48KB unique)
│   ├── got/9.6.0/* (84.23KB - 83.02KB unique)
│   ├── graceful-fs/4.2.11/* (32.21KB - 32.16KB unique)
│   ├─┬ has-flag (8.21KB - 6.01KB unique)
│   │ ├── 3.0.0/* (3.47KB - 2.37KB unique)
│   │ └── 4.0.0/* (4.74KB - 3.64KB unique)
│   ├── has-property-descriptors/1.0.2/* (11.94KB - 11.78KB unique)
│   ├── has-symbols/1.1.0/* (24.09KB - 23.86KB unique)
│   ├── has-tostringtag/1.0.2/* (18.45KB - 18.1KB unique)
│   ├── hasown/2.0.2/* (9.7KB - 9.42KB unique)
│   ├── highlight.js/10.7.3/* (1.67MB - 1.53MB unique)
│   ├── http-cache-semantics/4.1.1/* (35.54KB - 35.53KB unique)
│   ├── human-signals/5.0.0/* (25.59KB)
│   ├── humanize-ms/1.2.1/* (4.17KB - 4.15KB unique)
│   ├── indent-string/5.0.0/* (4.8KB - 3.71KB unique)
│   ├── inherits/2.0.4/* (4.28KB - 4.26KB unique)
│   ├── ini/1.3.8/* (9.52KB)
│   ├── ink/5.2.0/* (292.65KB - 292.64KB unique)
│   ├── ink-markdown/1.0.4/* (3.25KB - 3.2KB unique)
│   ├── ink-text-input/6.0.0/* (14.82KB - 13.73KB unique)
│   ├── is-docker/3.0.0/* (3.24KB - 2.15KB unique)
│   ├─┬ is-fullwidth-code-point (14.15KB - 9.78KB unique)
│   │ ├── 3.0.0/* (5.36KB - 4.24KB unique)
│   │ ├── 4.0.0/* (5.24KB - 3.61KB unique)
│   │ └── 5.0.0/* (3.55KB - 1.92KB unique)
│   ├── is-in-ci/1.0.0/* (4.13KB - 3.04KB unique)
│   ├── is-inside-container/1.0.0/* (3.57KB - 2.48KB unique)
│   ├── is-stream/3.0.0/* (6.24KB - 5.15KB unique)
│   ├── is-wsl/3.1.0/* (3.53KB - 2.44KB unique)
│   ├── is64bit/2.0.0/* (5.04KB - 3.95KB unique)
│   ├── isarray/1.0.0/* (4.23KB - 4.18KB unique)
│   ├── isexe/2.0.0/* (11.26KB - 10.46KB unique)
│   ├── jmespath/0.15.0/* (218.68KB - 218.58KB unique)
│   ├── js-tokens/4.0.0/* (15.36KB)
│   ├── json-buffer/3.0.0/* (5.77KB - 5.73KB unique)
│   ├── json-stringify-safe/5.0.1/* (13.36KB - 12.59KB unique)
│   ├── jsonfile/4.0.0/* (17.04KB - 17.03KB unique)
│   ├── keyv/3.1.0/* (14.65KB - 13.59KB unique)
│   ├── leven/2.1.0/* (5.1KB - 4KB unique)
│   ├── lodash/4.17.21/* (1.37MB - 1.35MB unique)
│   ├── loose-envify/1.4.0/* (6.14KB - 6.08KB unique)
│   ├─┬ lowercase-keys (6KB - 3.79KB unique)
│   │ ├── 1.0.1/* (2.84KB - 1.73KB unique)
│   │ └── 2.0.0/* (3.16KB - 2.05KB unique)
│   ├─┬ marked (2.56MB - 2.51MB unique)
│   │ ├── 11.0.1/* (891.5KB - 872.67KB unique)
│   │ ├── 6.0.0/* (836.69KB - 833.82KB unique)
│   │ └── 9.1.6/* (892.55KB - 865.52KB unique)
│   ├─┬ marked-terminal (3.72MB - 3.71MB unique)
│   │ ├── 6.3.0/* (1.85MB)
│   │ └── 7.3.0/* (1.87MB - 1.86MB unique)
│   ├── matcher/3.0.0/* (9.05KB - 7.95KB unique)
│   ├── math-intrinsics/1.1.0/* (18.31KB - 16.67KB unique)
│   ├── merge-stream/2.0.0/* (4.58KB - 4.57KB unique)
│   ├── mime-db/1.52.0/* (201.25KB - 201.24KB unique)
│   ├── mime-types/2.1.35/* (18.49KB)
│   ├─┬ mimic-fn (12.94KB - 10.73KB unique)
│   │ ├── 2.1.0/* (4.79KB - 3.67KB unique)
│   │ └── 4.0.0/* (8.15KB - 7.05KB unique)
│   ├── mimic-response/1.0.1/* (3.93KB - 2.84KB unique)
│   ├── minimatch/3.0.8/* (34.2KB - 33.44KB unique)
│   ├── minimist/1.2.8/* (54.57KB - 53.32KB unique)
│   ├── mkdirp/0.5.6/* (8.13KB - 8.1KB unique)
│   ├── mri/1.1.4/* (9.58KB - 9.57KB unique)
│   ├─┬ ms (13.46KB - 13.44KB unique)
│   │ ├── 2.0.0/* (6.52KB - 6.51KB unique)
│   │ └── 2.1.3/* (6.94KB - 6.93KB unique)
│   ├── mz/2.7.0/* (10.21KB - 10.16KB unique)
│   ├── node-domexception/1.0.0/* (30.84KB - 25.55KB unique)
│   ├── node-emoji/2.2.0/* (63.15KB - 60.91KB unique)
│   ├── node-fetch/2.7.0/* (159.01KB - 159KB unique)
│   ├── normalize-url/4.5.1/* (18.14KB - 17.02KB unique)
│   ├── npm-conf/1.1.3/* (20.86KB - 20.83KB unique)
│   ├── npm-run-path/5.3.0/* (8.43KB - 7.34KB unique)
│   ├── oak/9.0.0/* (37.22KB - 37.15KB unique)
│   ├── object-assign/4.1.1/* (5.8KB - 4.7KB unique)
│   ├── object-keys/1.1.1/* (27.02KB - 26.71KB unique)
│   ├── once/1.4.0/* (4.3KB - 3.55KB unique)
│   ├─┬ onetime (12.39KB - 10.19KB unique)
│   │ ├── 5.1.2/* (6.48KB - 5.38KB unique)
│   │ └── 6.0.0/* (5.9KB - 4.81KB unique)
│   ├── openai/4.91.0/* (3.57MB - 3.54MB unique)
│   ├── p-cancelable/1.1.0/* (12.69KB - 11.6KB unique)
│   ├─┬ parse5 (654.78KB - 433.9KB unique)
│   │ ├── 5.1.1/* (327.23KB - 327.03KB unique)
│   │ └── 6.0.1/* (327.55KB - 106.87KB unique)
│   ├── parse5-htmlparser2-tree-adapter/6.0.1/* (12.37KB - 10.48KB unique)
│   ├── patch-console/2.0.0/* (6.01KB)
│   ├─┬ path-key (9.02KB - 6.81KB unique)
│   │ ├── 3.1.1/* (4.89KB - 3.77KB unique)
│   │ └── 4.0.0/* (4.13KB - 3.04KB unique)
│   ├── path-to-regexp/6.3.0/* (110.48KB - 110.46KB unique)
│   ├── pend/1.2.0/* (6.25KB - 6.23KB unique)
│   ├── pify/3.0.0/* (7.29KB - 6.19KB unique)
│   ├── pino/5.17.0/* (278.07KB - 277.42KB unique)
│   ├── pino-pretty/2.6.1/* (217.92KB - 217.85KB unique)
│   ├── pino-std-serializers/2.5.0/* (24.76KB - 24.53KB unique)
│   ├── prepend-http/2.0.0/* (3.34KB - 2.24KB unique)
│   ├── process-nextick-args/2.0.1/* (3.49KB)
│   ├── progress/2.0.3/* (15.9KB - 15.87KB unique)
│   ├── proto-list/1.2.4/* (5.12KB - 4.35KB unique)
│   ├── pump/3.0.2/* (9.16KB - 8.04KB unique)
│   ├── quick-format-unescaped/3.0.3/* (9.79KB - 9.75KB unique)
│   ├── react/18.3.1/* (314.18KB - 311.74KB unique)
│   ├── react-reconciler/0.29.2/* (968.11KB - 966.07KB unique)
│   ├─┬ readable-stream (210.22KB - 200.44KB unique)
│   │ ├── 2.3.8/* (87.73KB - 87.46KB unique)
│   │ └── 3.6.2/* (122.49KB - 112.98KB unique)
│   ├── require-directory/2.1.1/* (12.46KB - 12.41KB unique)
│   ├── responselike/1.0.2/* (4.94KB - 4.93KB unique)
│   ├── restore-cursor/4.0.0/* (3.31KB - 2.22KB unique)
│   ├── roarr/2.15.4/* (70.08KB - 68.39KB unique)
│   ├─┬ safe-buffer (63.24KB - 34.5KB unique)
│   │ ├── 5.1.2/* (31.42KB - 31.4KB unique)
│   │ └── 5.2.1/* (31.82KB - 3.1KB unique)
│   ├── scheduler/0.23.2/* (98.51KB - 87.36KB unique)
│   ├─┬ semver (165.23KB - 161.94KB unique)
│   │ ├── 6.3.1/* (67.94KB - 67.18KB unique)
│   │ └── 7.7.1/* (97.29KB - 94.76KB unique)
│   ├── semver-compare/1.0.0/* (4.6KB - 3.51KB unique)
│   ├── serialize-error/7.0.1/* (7.23KB - 6.13KB unique)
│   ├── shebang-command/2.0.0/* (2.93KB - 1.83KB unique)
│   ├── shebang-regex/3.0.0/* (3.2KB - 2.1KB unique)
│   ├─┬ signal-exit (87.45KB - 83.23KB unique)
│   │ ├── 3.0.7/* (10.19KB - 10.18KB unique)
│   │ └── 4.1.0/* (77.26KB - 73.05KB unique)
│   ├── skin-tone/2.0.0/* (5.06KB - 3.95KB unique)
│   ├─┬ slice-ansi (14.35KB - 13.22KB unique)
│   │ ├── 5.0.0/* (6.42KB)
│   │ └── 7.1.0/* (7.93KB - 6.79KB unique)
│   ├── sonic-boom/0.7.7/* (30.14KB - 30.06KB unique)
│   ├── split2/3.2.2/* (17.24KB - 17.2KB unique)
│   ├── sprintf-js/1.1.3/* (40.42KB - 40.36KB unique)
│   ├── stack-utils/2.0.6/* (14.63KB - 14.62KB unique)
│   ├─┬ string-width (13.22KB - 11.01KB unique)
│   │ ├── 4.2.3/* (5.47KB - 4.35KB unique)
│   │ └── 7.2.0/* (7.75KB - 6.66KB unique)
│   ├─┬ string_decoder (30.04KB - 16.72KB unique)
│   │ ├── 1.1.1/* (15.54KB)
│   │ └── 1.3.0/* (14.5KB - 1.18KB unique)
│   ├─┬ strip-ansi (8.75KB - 6.55KB unique)
│   │ ├── 6.0.1/* (4.37KB - 3.26KB unique)
│   │ └── 7.1.0/* (4.38KB - 3.29KB unique)
│   ├── strip-final-newline/3.0.0/* (3.45KB - 2.36KB unique)
│   ├── sumchecker/3.0.1/* (222.24KB - 222.2KB unique)
│   ├─┬ supports-color (14.39KB - 12KB unique)
│   │ ├── 5.5.0/* (7KB - 5.85KB unique)
│   │ └── 7.2.0/* (7.39KB - 6.14KB unique)
│   ├── supports-hyperlinks/3.2.0/* (7.36KB - 7.35KB unique)
│   ├── system-architecture/0.1.0/* (5.42KB - 4.33KB unique)
│   ├── thenify/3.3.1/* (8.26KB - 8.25KB unique)
│   ├── thenify-all/1.6.0/* (6.97KB - 6.96KB unique)
│   ├── to-readable-stream/1.0.0/* (3.17KB - 2.07KB unique)
│   ├── tr46/0.0.3/* (262.19KB - 262.17KB unique)
│   ├── tunnel/0.0.6/* (65.03KB - 64.91KB unique)
│   ├─┬ type-fest (514.14KB - 510.86KB unique)
│   │ ├── 0.13.1/* (87.04KB - 86.75KB unique)
│   │ └── 4.38.0/* (427.1KB - 424.11KB unique)
│   ├── typedarray/0.0.6/* (25.82KB - 25.72KB unique)
│   ├─┬ undici-types (154.2KB - 139.45KB unique)
│   │ ├── 5.26.5/* (71.96KB - 71.58KB unique)
│   │ └── 6.20.0/* (82.24KB - 67.87KB unique)
│   ├── unicode-emoji-modifier-base/1.0.0/* (3.42KB - 2.35KB unique)
│   ├── universalify/0.1.2/* (5.05KB)
│   ├── url-parse-lax/3.0.0/* (4.56KB - 3.47KB unique)
│   ├── util-deprecate/1.0.2/* (5.91KB - 5.88KB unique)
│   ├── uuid/3.3.3/* (34.83KB - 34.67KB unique)
│   ├── web-streams-polyfill/4.0.0-beta.3/* (413.47KB - 413.4KB unique)
│   ├── webidl-conversions/3.0.1/* (12.48KB - 12.47KB unique)
│   ├── whatwg-url/5.0.0/* (49.75KB)
│   ├── which/2.0.2/* (10.23KB - 9.46KB unique)
│   ├── widest-line/5.0.0/* (3.46KB - 2.37KB unique)
│   ├─┬ wrap-ansi (22.19KB - 20KB unique)
│   │ ├── 7.0.0/* (10.82KB - 9.71KB unique)
│   │ └── 9.0.0/* (11.37KB - 10.28KB unique)
│   ├── wrappy/1.0.2/* (3.24KB - 2.48KB unique)
│   ├── ws/8.18.1/* (144.33KB - 144.22KB unique)
│   ├── y18n/5.0.8/* (23.08KB - 23.07KB unique)
│   ├── yargs/16.2.0/* (279.81KB - 279.74KB unique)
│   ├── yargs-parser/20.2.9/* (121.51KB - 121.5KB unique)
│   ├── yauzl/2.10.0/* (65.23KB)
│   ├── yoga-layout/3.2.1/* (219.02KB)
│   ├── zod/3.24.2/* (690.68KB - 686.95KB unique)
│   ├── zod-to-json-schema/3.24.5/* (211.4KB - 207.62KB unique)
│   └── zustand/5.0.3/* (88.01KB - 83.23KB unique)
├── deno.json (478B)
└─┬ src (241.22KB)
  ├── api/* (7.39KB)
  ├── components/* (41.24KB)
  ├── main.ts (1.96KB)
  ├── services/* (120.95KB)
  ├── store/* (22.03KB)
  └── utils/* (47.65KB)

Files: 33.58MB
Metadata: 15.11KB
Remote modules: 1.88MB
```

```powershell
PS S:\unibearpatch\unibear> deno task compile-no-check
Task compile-no-check deno compile -A --no-check -o bin/unibear src/main.ts
Compile file:///S:/unibearpatch/unibear/src/main.ts to bin/unibear.exe

Embedded Files

unibear.exe
├─┬ .deno_compile_node_modules (34.15MB - 32.76MB unique)
│ └─┬ localhost (34.15MB - 32.76MB unique)
│   ├── @alcalzone/ansi-tokenize/* (23.8KB)
│   ├── @colors/colors/* (39.28KB - 39.1KB unique)
│   ├── @electron/get/* (95.67KB - 87.42KB unique)
│   ├── @sindresorhus/is/* (96.5KB - 96.44KB unique)
│   ├── @szmarczak/http-timer/* (6.52KB - 6.51KB unique)
│   ├─┬ @types (4.91MB - 4.89MB unique)
│   │ ├── marked-terminal/* (7.06KB - 7.05KB unique)
│   │ ├── node/* (4.89MB - 4.87MB unique)
│   │ └── node-fetch/* (12.1KB - 10.96KB unique)
│   ├── abort-controller/3.0.0/* (75.86KB - 75.83KB unique)
│   ├── agentkeepalive/4.6.0/* (33.81KB - 33.77KB unique)
│   ├─┬ ansi-escapes (34.96KB - 32.71KB unique)
│   │ ├── 6.2.1/* (17.36KB - 16.27KB unique)
│   │ └── 7.0.0/* (17.59KB - 16.44KB unique)
│   ├─┬ ansi-regex (11.35KB - 9.15KB unique)
│   │ ├── 5.0.1/* (5.9KB - 4.8KB unique)
│   │ └── 6.1.0/* (5.45KB - 4.35KB unique)
│   ├─┬ ansi-styles (43.86KB - 40.56KB unique)
│   │ ├── 3.2.1/* (9.58KB - 8.48KB unique)
│   │ ├── 4.3.0/* (17.02KB - 15.91KB unique)
│   │ └── 6.2.1/* (17.26KB - 16.17KB unique)
│   ├── any-promise/1.3.0/* (22.66KB - 22.23KB unique)
│   ├── args/5.0.3/* (31.22KB - 31.13KB unique)
│   ├── asynckit/0.4.0/* (27.53KB - 27.28KB unique)
│   ├── atomic-sleep/1.0.0/* (6.98KB - 6.96KB unique)
│   ├── auto-bind/5.0.1/* (6.8KB - 5.71KB unique)
│   ├── balanced-match/1.0.2/* (7.27KB - 7.24KB unique)
│   ├── boolean/3.2.0/* (12.96KB - 12.92KB unique)
│   ├── brace-expansion/1.1.11/* (11.22KB - 11.21KB unique)
│   ├── buffer-crc32/0.2.13/* (8.18KB - 8.17KB unique)
│   ├── buffer-from/1.1.2/* (5.27KB - 5.26KB unique)
│   ├── cacheable-request/6.1.0/* (16.75KB - 16.74KB unique)
│   ├── call-bind-apply-helpers/1.0.2/* (16.98KB - 16.83KB unique)
│   ├── camelcase/5.0.0/* (5.39KB - 4.29KB unique)
│   ├─┬ chalk (104.91KB - 96.52KB unique)
│   │ ├── 2.4.2/* (26.9KB - 25.79KB unique)
│   │ ├── 4.1.2/* (34.65KB - 33.53KB unique)
│   │ └── 5.4.1/* (43.36KB - 37.19KB unique)
│   ├── char-regex/1.0.2/* (5.26KB - 5.24KB unique)
│   ├── cli-boxes/3.0.0/* (6.84KB - 5.74KB unique)
│   ├── cli-cursor/4.0.0/* (4.51KB - 3.42KB unique)
│   ├── cli-highlight/2.1.11/* (43.53KB - 43.4KB unique)
│   ├── cli-table3/0.6.5/* (45.9KB - 45.85KB unique)
│   ├── cli-truncate/4.0.0/* (10.8KB - 9.71KB unique)
│   ├── clipboardy/4.0.0/* (894.14KB - 893.05KB unique)
│   ├── cliui/7.0.4/* (29.89KB - 29.88KB unique)
│   ├── clone-response/1.0.3/* (4.79KB - 3.73KB unique)
│   ├── code-excerpt/4.0.0/* (4.28KB)
│   ├─┬ color-convert (54.37KB - 49.08KB unique)
│   │ ├── 1.9.3/* (27.16KB - 27.14KB unique)
│   │ └── 2.0.1/* (27.21KB - 21.94KB unique)
│   ├─┬ color-name (21.59KB - 13.18KB unique)
│   │ ├── 1.1.3/* (12.21KB - 12.19KB unique)
│   │ └── 1.1.4/* (9.39KB - 1010B unique)
│   ├── combined-stream/1.0.8/* (11.91KB - 11.89KB unique)
│   ├── commander/2.19.0/* (60.56KB - 60.55KB unique)
│   ├── concat-map/0.0.1/* (5.19KB - 5.14KB unique)
│   ├── concat-stream/1.6.2/* (9.75KB - 9.74KB unique)
│   ├── config-chain/1.1.13/* (15.09KB)
│   ├── convert-to-spaces/2.0.1/* (3.07KB)
│   ├── core-util-is/1.0.3/* (5.54KB)
│   ├── cross-spawn/7.0.6/* (16.36KB - 16.33KB unique)
│   ├── dateformat/3.0.3/* (15.13KB - 15.12KB unique)
│   ├─┬ debug (94.98KB - 94.32KB unique)
│   │ ├── 2.6.9/* (52.38KB - 51.87KB unique)
│   │ └── 4.4.0/* (42.6KB - 42.45KB unique)
│   ├── decompress-response/3.3.0/* (3.9KB - 3.89KB unique)
│   ├── defer-to-connect/1.1.3/* (5.75KB - 4.65KB unique)
│   ├── define-data-property/1.1.4/* (31.39KB - 31.36KB unique)
│   ├── define-properties/1.2.1/* (13.96KB - 13.81KB unique)
│   ├── delayed-stream/1.0.0/* (8.46KB - 7.38KB unique)
│   ├── detect-node/2.1.0/* (3.03KB - 3KB unique)
│   ├── diff/7.0.0/* (609.9KB - 539.25KB unique)
│   ├── dunder-proto/1.0.1/* (13.95KB - 13.65KB unique)
│   ├── duplexer3/0.1.5/* (6.02KB)
│   ├── electron/9.4.4/* (568.04KB - 567.98KB unique)
│   ├─┬ emoji-regex (79.38KB - 78.25KB unique)
│   │ ├── 10.4.0/* (31.73KB - 31.71KB unique)
│   │ └── 8.0.0/* (47.65KB - 46.54KB unique)
│   ├── emojilib/2.4.0/* (319.31KB)
│   ├── encodeurl/1.0.2/* (8.2KB - 8.19KB unique)
│   ├── end-of-stream/1.4.4/* (6.5KB - 6.49KB unique)
│   ├── env-paths/2.2.1/* (10.33KB - 9.21KB unique)
│   ├── environment/1.1.0/* (8.84KB - 7.75KB unique)
│   ├── es-define-property/1.0.1/* (11.22KB - 10.01KB unique)
│   ├── es-errors/1.3.0/* (13.2KB - 11.93KB unique)
│   ├── es-object-atoms/1.1.1/* (12.31KB - 11.15KB unique)
│   ├── es-set-tostringtag/2.1.0/* (15.24KB - 15.07KB unique)
│   ├── es-toolkit/1.33.0/* (2.66MB - 2.07MB unique)
│   ├── es6-error/4.1.1/* (10.26KB - 10.2KB unique)
│   ├── escalade/3.2.0/* (12.54KB - 12.49KB unique)
│   ├─┬ escape-string-regexp (10.89KB - 8.2KB unique)
│   │ ├── 1.0.5/* (3.08KB - 3.07KB unique)
│   │ ├── 2.0.0/* (3.65KB - 2.54KB unique)
│   │ └── 4.0.0/* (4.16KB - 2.59KB unique)
│   ├── event-target-shim/5.0.1/* (185.77KB - 185.75KB unique)
│   ├── eventemitter2/5.0.1/* (39.88KB - 39.84KB unique)
│   ├── execa/8.0.1/* (78.42KB - 77.33KB unique)
│   ├── extract-zip/1.7.0/* (11.04KB - 11KB unique)
│   ├── fast-json-parse/1.0.3/* (7.35KB - 7.31KB unique)
│   ├── fast-redact/2.1.0/* (69.71KB - 69.54KB unique)
│   ├── fast-safe-stringify/2.1.1/* (39.39KB - 39.32KB unique)
│   ├── fd-slicer/1.1.0/* (29.95KB - 29.93KB unique)
│   ├── flatstr/1.0.12/* (12.76KB - 12.71KB unique)
│   ├── form-data/4.0.2/* (31.62KB - 31.57KB unique)
│   ├── form-data-encoder/1.7.2/* (47.28KB - 46.78KB unique)
│   ├── formdata-node/4.4.1/* (86.76KB - 85.29KB unique)
│   ├── fs-extra/8.1.0/* (126.55KB - 126.42KB unique)
│   ├── fullscreen-ink/0.0.2/* (9.62KB - 9.52KB unique)
│   ├── function-bind/1.1.2/* (32.34KB - 32.09KB unique)
│   ├── get-caller-file/2.0.5/* (5.29KB - 5.27KB unique)
│   ├── get-east-asian-width/1.3.0/* (15.49KB - 14.4KB unique)
│   ├── get-intrinsic/1.3.0/* (46.65KB - 46.49KB unique)
│   ├── get-proto/1.0.1/* (11.81KB - 11.59KB unique)
│   ├─┬ get-stream (45.51KB - 42.21KB unique)
│   │ ├── 4.1.0/* (8.17KB - 7.08KB unique)
│   │ ├── 5.2.0/* (12.61KB - 11.5KB unique)
│   │ └── 8.0.1/* (24.72KB - 23.63KB unique)
│   ├── global-agent/3.0.0/* (132.72KB - 110.95KB unique)
│   ├── global-tunnel-ng/2.7.1/* (39.29KB - 39.25KB unique)
│   ├── globalthis/1.0.4/* (24.19KB - 24.06KB unique)
│   ├── gopd/1.2.0/* (10.65KB - 10.48KB unique)
│   ├── got/9.6.0/* (84.23KB - 83.02KB unique)
│   ├── graceful-fs/4.2.11/* (32.21KB - 32.16KB unique)
│   ├─┬ has-flag (8.21KB - 6.01KB unique)
│   │ ├── 3.0.0/* (3.47KB - 2.37KB unique)
│   │ └── 4.0.0/* (4.74KB - 3.64KB unique)
│   ├── has-property-descriptors/1.0.2/* (11.94KB - 11.78KB unique)
│   ├── has-symbols/1.1.0/* (24.09KB - 23.86KB unique)
│   ├── has-tostringtag/1.0.2/* (18.45KB - 18.1KB unique)
│   ├── hasown/2.0.2/* (9.7KB - 9.42KB unique)
│   ├── highlight.js/10.7.3/* (1.67MB - 1.53MB unique)
│   ├── http-cache-semantics/4.1.1/* (35.54KB - 35.53KB unique)
│   ├── human-signals/5.0.0/* (25.59KB)
│   ├── humanize-ms/1.2.1/* (4.17KB - 4.15KB unique)
│   ├── indent-string/5.0.0/* (4.8KB - 3.71KB unique)
│   ├── inherits/2.0.4/* (4.28KB - 4.26KB unique)
│   ├── ini/1.3.8/* (9.52KB)
│   ├── ink/5.2.0/* (292.65KB - 292.64KB unique)
│   ├── ink-markdown/1.0.4/* (3.25KB - 3.2KB unique)
│   ├── ink-text-input/6.0.0/* (14.82KB - 13.73KB unique)
│   ├── is-docker/3.0.0/* (3.24KB - 2.15KB unique)
│   ├─┬ is-fullwidth-code-point (14.15KB - 9.78KB unique)
│   │ ├── 3.0.0/* (5.36KB - 4.24KB unique)
│   │ ├── 4.0.0/* (5.24KB - 3.61KB unique)
│   │ └── 5.0.0/* (3.55KB - 1.92KB unique)
│   ├── is-in-ci/1.0.0/* (4.13KB - 3.04KB unique)
│   ├── is-inside-container/1.0.0/* (3.57KB - 2.48KB unique)
│   ├── is-stream/3.0.0/* (6.24KB - 5.15KB unique)
│   ├── is-wsl/3.1.0/* (3.53KB - 2.44KB unique)
│   ├── is64bit/2.0.0/* (5.04KB - 3.95KB unique)
│   ├── isarray/1.0.0/* (4.23KB - 4.18KB unique)
│   ├── isexe/2.0.0/* (11.26KB - 10.46KB unique)
│   ├── jmespath/0.15.0/* (218.68KB - 218.58KB unique)
│   ├── js-tokens/4.0.0/* (15.36KB)
│   ├── json-buffer/3.0.0/* (5.77KB - 5.73KB unique)
│   ├── json-stringify-safe/5.0.1/* (13.36KB - 12.59KB unique)
│   ├── jsonfile/4.0.0/* (17.04KB - 17.03KB unique)
│   ├── keyv/3.1.0/* (14.65KB - 13.59KB unique)
│   ├── leven/2.1.0/* (5.1KB - 4KB unique)
│   ├── lodash/4.17.21/* (1.37MB - 1.35MB unique)
│   ├── loose-envify/1.4.0/* (6.14KB - 6.08KB unique)
│   ├─┬ lowercase-keys (6KB - 3.79KB unique)
│   │ ├── 1.0.1/* (2.84KB - 1.73KB unique)
│   │ └── 2.0.0/* (3.16KB - 2.05KB unique)
│   ├─┬ marked (2.56MB - 2.51MB unique)
│   │ ├── 11.0.1/* (891.5KB - 872.67KB unique)
│   │ ├── 6.0.0/* (836.69KB - 833.82KB unique)
│   │ └── 9.1.6/* (892.55KB - 865.52KB unique)
│   ├─┬ marked-terminal (3.72MB - 3.71MB unique)
│   │ ├── 6.3.0/* (1.85MB)
│   │ └── 7.3.0/* (1.87MB - 1.86MB unique)
│   ├── matcher/3.0.0/* (9.05KB - 7.95KB unique)
│   ├── math-intrinsics/1.1.0/* (18.31KB - 16.67KB unique)
│   ├── merge-stream/2.0.0/* (4.58KB - 4.57KB unique)
│   ├── mime-db/1.52.0/* (201.25KB - 201.24KB unique)
│   ├── mime-types/2.1.35/* (18.49KB)
│   ├─┬ mimic-fn (12.94KB - 10.73KB unique)
│   │ ├── 2.1.0/* (4.79KB - 3.67KB unique)
│   │ └── 4.0.0/* (8.15KB - 7.05KB unique)
│   ├── mimic-response/1.0.1/* (3.93KB - 2.84KB unique)
│   ├── minimatch/3.0.8/* (34.2KB - 33.44KB unique)
│   ├── minimist/1.2.8/* (54.57KB - 53.32KB unique)
│   ├── mkdirp/0.5.6/* (8.13KB - 8.1KB unique)
│   ├── mri/1.1.4/* (9.58KB - 9.57KB unique)
│   ├─┬ ms (13.46KB - 13.44KB unique)
│   │ ├── 2.0.0/* (6.52KB - 6.51KB unique)
│   │ └── 2.1.3/* (6.94KB - 6.93KB unique)
│   ├── mz/2.7.0/* (10.21KB - 10.16KB unique)
│   ├── node-domexception/1.0.0/* (30.84KB - 25.55KB unique)
│   ├── node-emoji/2.2.0/* (63.15KB - 60.91KB unique)
│   ├── node-fetch/2.7.0/* (159.01KB - 159KB unique)
│   ├── normalize-url/4.5.1/* (18.14KB - 17.02KB unique)
│   ├── npm-conf/1.1.3/* (20.86KB - 20.83KB unique)
│   ├── npm-run-path/5.3.0/* (8.43KB - 7.34KB unique)
│   ├── oak/9.0.0/* (37.22KB - 37.15KB unique)
│   ├── object-assign/4.1.1/* (5.8KB - 4.7KB unique)
│   ├── object-keys/1.1.1/* (27.02KB - 26.71KB unique)
│   ├── once/1.4.0/* (4.3KB - 3.55KB unique)
│   ├─┬ onetime (12.39KB - 10.19KB unique)
│   │ ├── 5.1.2/* (6.48KB - 5.38KB unique)
│   │ └── 6.0.0/* (5.9KB - 4.81KB unique)
│   ├── openai/4.91.0/* (3.57MB - 3.54MB unique)
│   ├── p-cancelable/1.1.0/* (12.69KB - 11.6KB unique)
│   ├─┬ parse5 (654.78KB - 433.9KB unique)
│   │ ├── 5.1.1/* (327.23KB - 327.03KB unique)
│   │ └── 6.0.1/* (327.55KB - 106.87KB unique)
│   ├── parse5-htmlparser2-tree-adapter/6.0.1/* (12.37KB - 10.48KB unique)
│   ├── patch-console/2.0.0/* (6.01KB)
│   ├─┬ path-key (9.02KB - 6.81KB unique)
│   │ ├── 3.1.1/* (4.89KB - 3.77KB unique)
│   │ └── 4.0.0/* (4.13KB - 3.04KB unique)
│   ├── path-to-regexp/6.3.0/* (110.48KB - 110.46KB unique)
│   ├── pend/1.2.0/* (6.25KB - 6.23KB unique)
│   ├── pify/3.0.0/* (7.29KB - 6.19KB unique)
│   ├── pino/5.17.0/* (278.07KB - 277.42KB unique)
│   ├── pino-pretty/2.6.1/* (217.92KB - 217.85KB unique)
│   ├── pino-std-serializers/2.5.0/* (24.76KB - 24.53KB unique)
│   ├── prepend-http/2.0.0/* (3.34KB - 2.24KB unique)
│   ├── process-nextick-args/2.0.1/* (3.49KB)
│   ├── progress/2.0.3/* (15.9KB - 15.87KB unique)
│   ├── proto-list/1.2.4/* (5.12KB - 4.35KB unique)
│   ├── pump/3.0.2/* (9.16KB - 8.04KB unique)
│   ├── quick-format-unescaped/3.0.3/* (9.79KB - 9.75KB unique)
│   ├── react/18.3.1/* (314.18KB - 311.74KB unique)
│   ├── react-reconciler/0.29.2/* (968.11KB - 966.07KB unique)
│   ├─┬ readable-stream (210.22KB - 200.44KB unique)
│   │ ├── 2.3.8/* (87.73KB - 87.46KB unique)
│   │ └── 3.6.2/* (122.49KB - 112.98KB unique)
│   ├── require-directory/2.1.1/* (12.46KB - 12.41KB unique)
│   ├── responselike/1.0.2/* (4.94KB - 4.93KB unique)
│   ├── restore-cursor/4.0.0/* (3.31KB - 2.22KB unique)
│   ├── roarr/2.15.4/* (70.08KB - 68.39KB unique)
│   ├─┬ safe-buffer (63.24KB - 34.5KB unique)
│   │ ├── 5.1.2/* (31.42KB - 31.4KB unique)
│   │ └── 5.2.1/* (31.82KB - 3.1KB unique)
│   ├── scheduler/0.23.2/* (98.51KB - 87.36KB unique)
│   ├─┬ semver (165.23KB - 161.94KB unique)
│   │ ├── 6.3.1/* (67.94KB - 67.18KB unique)
│   │ └── 7.7.1/* (97.29KB - 94.76KB unique)
│   ├── semver-compare/1.0.0/* (4.6KB - 3.51KB unique)
│   ├── serialize-error/7.0.1/* (7.23KB - 6.13KB unique)
│   ├── shebang-command/2.0.0/* (2.93KB - 1.83KB unique)
│   ├── shebang-regex/3.0.0/* (3.2KB - 2.1KB unique)
│   ├─┬ signal-exit (87.45KB - 83.23KB unique)
│   │ ├── 3.0.7/* (10.19KB - 10.18KB unique)
│   │ └── 4.1.0/* (77.26KB - 73.05KB unique)
│   ├── skin-tone/2.0.0/* (5.06KB - 3.95KB unique)
│   ├─┬ slice-ansi (14.35KB - 13.22KB unique)
│   │ ├── 5.0.0/* (6.42KB)
│   │ └── 7.1.0/* (7.93KB - 6.79KB unique)
│   ├── sonic-boom/0.7.7/* (30.14KB - 30.06KB unique)
│   ├── split2/3.2.2/* (17.24KB - 17.2KB unique)
│   ├── sprintf-js/1.1.3/* (40.42KB - 40.36KB unique)
│   ├── stack-utils/2.0.6/* (14.63KB - 14.62KB unique)
│   ├─┬ string-width (13.22KB - 11.01KB unique)
│   │ ├── 4.2.3/* (5.47KB - 4.35KB unique)
│   │ └── 7.2.0/* (7.75KB - 6.66KB unique)
│   ├─┬ string_decoder (30.04KB - 16.72KB unique)
│   │ ├── 1.1.1/* (15.54KB)
│   │ └── 1.3.0/* (14.5KB - 1.18KB unique)
│   ├─┬ strip-ansi (8.75KB - 6.55KB unique)
│   │ ├── 6.0.1/* (4.37KB - 3.26KB unique)
│   │ └── 7.1.0/* (4.38KB - 3.29KB unique)
│   ├── strip-final-newline/3.0.0/* (3.45KB - 2.36KB unique)
│   ├── sumchecker/3.0.1/* (222.24KB - 222.2KB unique)
│   ├─┬ supports-color (14.39KB - 12KB unique)
│   │ ├── 5.5.0/* (7KB - 5.85KB unique)
│   │ └── 7.2.0/* (7.39KB - 6.14KB unique)
│   ├── supports-hyperlinks/3.2.0/* (7.36KB - 7.35KB unique)
│   ├── system-architecture/0.1.0/* (5.42KB - 4.33KB unique)
│   ├── thenify/3.3.1/* (8.26KB - 8.25KB unique)
│   ├── thenify-all/1.6.0/* (6.97KB - 6.96KB unique)
│   ├── to-readable-stream/1.0.0/* (3.17KB - 2.07KB unique)
│   ├── tr46/0.0.3/* (262.19KB - 262.17KB unique)
│   ├── tunnel/0.0.6/* (65.03KB - 64.91KB unique)
│   ├─┬ type-fest (514.14KB - 510.86KB unique)
│   │ ├── 0.13.1/* (87.04KB - 86.75KB unique)
│   │ └── 4.38.0/* (427.1KB - 424.11KB unique)
│   ├── typedarray/0.0.6/* (25.82KB - 25.72KB unique)
│   ├─┬ undici-types (154.2KB - 139.45KB unique)
│   │ ├── 5.26.5/* (71.96KB - 71.58KB unique)
│   │ └── 6.20.0/* (82.24KB - 67.87KB unique)
│   ├── unicode-emoji-modifier-base/1.0.0/* (3.42KB - 2.35KB unique)
│   ├── universalify/0.1.2/* (5.05KB)
│   ├── url-parse-lax/3.0.0/* (4.56KB - 3.47KB unique)
│   ├── util-deprecate/1.0.2/* (5.91KB - 5.88KB unique)
│   ├── uuid/3.3.3/* (34.83KB - 34.67KB unique)
│   ├── web-streams-polyfill/4.0.0-beta.3/* (413.47KB - 413.4KB unique)
│   ├── webidl-conversions/3.0.1/* (12.48KB - 12.47KB unique)
│   ├── whatwg-url/5.0.0/* (49.75KB)
│   ├── which/2.0.2/* (10.23KB - 9.46KB unique)
│   ├── widest-line/5.0.0/* (3.46KB - 2.37KB unique)
│   ├─┬ wrap-ansi (22.19KB - 20KB unique)
│   │ ├── 7.0.0/* (10.82KB - 9.71KB unique)
│   │ └── 9.0.0/* (11.37KB - 10.28KB unique)
│   ├── wrappy/1.0.2/* (3.24KB - 2.48KB unique)
│   ├── ws/8.18.1/* (144.33KB - 144.22KB unique)
│   ├── y18n/5.0.8/* (23.08KB - 23.07KB unique)
│   ├── yargs/16.2.0/* (279.81KB - 279.74KB unique)
│   ├── yargs-parser/20.2.9/* (121.51KB - 121.5KB unique)
│   ├── yauzl/2.10.0/* (65.23KB)
│   ├── yoga-layout/3.2.1/* (219.02KB)
│   ├── zod/3.24.2/* (690.68KB - 686.95KB unique)
│   ├── zod-to-json-schema/3.24.5/* (211.4KB - 207.62KB unique)
│   └── zustand/5.0.3/* (88.01KB - 83.23KB unique)
├── deno.json (478B)
└─┬ src (241.22KB)
  ├── api/* (7.39KB)
  ├── components/* (41.24KB)
  ├── main.ts (1.96KB)
  ├── services/* (120.95KB)
  ├── store/* (22.03KB)
  └── utils/* (47.65KB)

Files: 33.58MB
Metadata: 15.11KB
Remote modules: 1.88MB

PS S:\unibearpatch\unibear>
```