### PR TITLE
Improve config directory detection on Windows and Unix (XDG)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .aider*
 bin/**
 .DS_Store
+unibear.md

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,7 +57,12 @@ export const fileExists = async (
 };
 
 export function getAppConfigDir(): string {
-  const xdgConfigHome = Deno.env.get("XDG_CONFIG_HOME") ??
+  if (Deno.build.os === "windows") {
+    const appData = Deno.env.get("APPDATA") ??
+      join(Deno.env.get("HOME") || "", "AppData", "Roaming");
+    return join(appData, "unibear");
+  }
+  const xdg = Deno.env.get("XDG_CONFIG_HOME") ??
     join(Deno.env.get("HOME") || "", ".config");
-  return join(xdgConfigHome, "unibear");
+  return join(xdg, "unibear");
 }


### PR DESCRIPTION
# Summary
Add Windows support for config directory resolution and ignore unibear.md

## Details
- Extend getAppConfigDir() in src/utils/helpers.ts:
  - Check `Deno.build.os === "windows"`.
  - On Windows, use `APPDATA` or fallback to `%HOME%\AppData\Roaming` and append `unibear`.
  - On other platforms, use `XDG_CONFIG_HOME` or default to `~/.config` and append `unibear`.
- Update .gitignore to exclude `unibear.md`.

This ensures Unibear stores configs in the correct platform-specific locations.
