### PR TITLE
Add local installation option

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+version=${1:-latest}
+
+if [[ "$version" == "--help" || "$version" == "-h" ]]; then
+  echo "Usage: $0 [version]"
+  echo "  version   Specify version (default: latest)"
+  exit 0
+fi
+
 owner=kamilmac
 repo=unibear
-version=${1:-latest}
 
 if [[ $version != "latest" ]]; then
   tag="download/$version"
@@ -50,7 +57,41 @@ echo "→ downloading $url"
 curl -fsSL "$url" -o /tmp/unibear${ext}
 chmod +x /tmp/unibear${ext}
 
-echo "→ installing to /usr/local/bin/unibear${ext}"
-sudo mv /tmp/unibear${ext} /usr/local/bin/unibear${ext}
+echo "→ installation location [user/system]:"
+echo "  user (u): ~/.local/bin (current user only)"
+echo "  system (s): /usr/local/bin (all users, requires sudo)"
+echo ""
+printf "❯ enter choice [user]: "
+read -r choice
 
-echo "✔ unibear ${version} installed"
+if [[ -z "$choice" ]]; then
+  choice="user"
+fi
+
+case "$choice" in
+  user|u)
+    INSTALL_DIR="$HOME/.local/bin"
+    mkdir -p "$INSTALL_DIR"
+    echo "→ installing user-local to $INSTALL_DIR/unibear${ext}"
+    mv /tmp/unibear${ext} "$INSTALL_DIR/unibear${ext}"
+    
+    # Check if ~/.local/bin is in PATH
+    if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+      echo ""
+      echo "⚠ $HOME/.local/bin is not in your PATH"
+      echo "   Add this to your shell config (~/.bashrc, ~/.zshrc, etc.):"
+      echo "   export PATH=\"\$HOME/.local/bin:\$PATH\""
+    fi
+    ;;
+  system|s)
+    INSTALL_DIR="/usr/local/bin"
+    echo "→ installing system-wide to $INSTALL_DIR/unibear${ext}"
+    sudo mv /tmp/unibear${ext} "$INSTALL_DIR/unibear${ext}"
+    ;;
+  *)
+    echo "✗ invalid choice '$choice'. please enter 'user' or 'system'."
+    exit 1
+    ;;
+esac
+
+echo "✔ unibear ${version} installed to $INSTALL_DIR"


### PR DESCRIPTION
Hi, when running the installation command: `curl -fsSL \
  https://raw.githubusercontent.com/kamilmac/unibear/main/install.sh \
  | bash`
  
  I got prompted for my sudo password. I prefer to install things in my local user without root requirements.
  
  I updated the `install.sh` to prompt the user to choose where they want to install unibear, defaulting to the user, not system.
  
  Examples:
  
  ```
$ ./install.sh

→ downloading https://github.com/kamilmac/unibear/releases/latest/download/unibear-linux_x86_64

→ installation location [user/system]:
  user (u): ~/.local/bin (current user only)
  system (s): /usr/local/bin (all users, requires sudo)

❯ enter choice [user]: 
→ installing user-local to /home/user/.local/bin/unibear

⚠ /home/user/.local/bin is not in your PATH
   Add this to your shell config (~/.bashrc, ~/.zshrc, etc.):
   export PATH="$HOME/.local/bin:$PATH"

✔ unibear latest installed to /home/user/.local/bin
  ```
  
  ```
  $ ./install.sh

→ downloading https://github.com/kamilmac/unibear/releases/latest/download/unibear-linux_x86_64

→ installation location [user/system]:
  user (u): ~/.local/bin (current user only)
  system (s): /usr/local/bin (all users, requires sudo)

❯ enter choice [user]: system
→ installing system-wide to /usr/local/bin/unibear
[sudo] password for user: 
✔ unibear latest installed to /usr/local/bin
```

```
$ ./install.sh

→ downloading https://github.com/kamilmac/unibear/releases/latest/download/unibear-linux_x86_64

→ installation location [user/system]:
  user (u): ~/.local/bin (current user only)
  system (s): /usr/local/bin (all users, requires sudo)

❯ enter choice [user]: global
✗ invalid choice 'global'. please enter 'user' or 'system'.
```